### PR TITLE
Use correct location of gna2-api.h in sample01

### DIFF
--- a/samples/src/sample01/sample01.cpp
+++ b/samples/src/sample01/sample01.cpp
@@ -5,7 +5,7 @@
 
 #define __STDC_WANT_LIB_EXT1__ 1
 
-#include "gna2-api.h"
+#include <gna3/gna2-api.h>
 
 #include <cinttypes>
 #include <cstdio>


### PR DESCRIPTION
Sample01 uses a local location of the header "gna2-api.h", it should probably use the installed one available at `$INSTALL_PREFIX/include/gna/`