### PR TITLE
Linux: search for the correct path of drm.h instead of hardcoding it

### DIFF
--- a/src/common/gna_drm.h
+++ b/src/common/gna_drm.h
@@ -4,7 +4,7 @@
 #ifndef _GNA_DRM_H_
 #define _GNA_DRM_H_
 
-#include "drm/drm.h"
+#include "drm.h"
 
 #include <linux/const.h>
 #include <linux/ioctl.h>

--- a/src/gna-lib/CMakeLists.txt
+++ b/src/gna-lib/CMakeLists.txt
@@ -295,7 +295,7 @@ set(GNA_ALL_TESTS_REGISTERED_TARGETS "gna-api;${GNA_ALL_TESTS_REGISTERED_TARGETS
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Android")
   set(gna_lib_headers ${gna_lib_headers} ${COMMON_DIR}/gna_drm.h)
-  set(DRM_INCLUDE_PATH /usr/include/drm)
+  find_path(DRM_INCLUDE_PATH drm.h HINTS /usr/include/drm /usr/include/libdrm)
 endif()
 
 target_include_directories(gna-obj PRIVATE


### PR DESCRIPTION
Some distro puts it in /usr/include/libdrm